### PR TITLE
Update Sonarqube and dependency-check issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <java.version>17</java.version>
         <docker.image.prefix>elrrservices</docker.image.prefix>
-        <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <start-class>com.deloitte.elrr.ElrrServicesApplication</start-class>
@@ -25,9 +24,10 @@
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>resuseReports</sonar.dynamicAnalysis>
         <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
-        <sona.lauguage>java</sona.lauguage>
-        <spring-security.version>6.4.5</spring-security.version>
+        <sonar.language>java</sonar.language>
+        <spring-security.version>6.4.6</spring-security.version>
         <lombok.version>1.18.36</lombok.version>
+        <tomcat.version>10.1.43</tomcat.version>
     </properties>
     <dependencies>
         <dependency>
@@ -117,6 +117,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>6.2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>6.2.9</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.11</version>
@@ -125,6 +135,17 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>fr.spacefox</groupId>
@@ -186,7 +207,7 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.16.0</version>
-            </dependency>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
@@ -224,7 +245,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>
@@ -264,7 +285,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcutil-jdk18on</artifactId>
-            <version>1.74</version> 
+            <version>1.74</version>
         </dependency>
     </dependencies>
     <build>
@@ -414,7 +435,7 @@
                         <!-- disable autorun because download size -->
                         <id>default</id>
                         <phase>none</phase>
-                    </execution> 
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/src/main/java/com/deloitte/elrr/services/dto/ClientTokenListItemDto.java
+++ b/src/main/java/com/deloitte/elrr/services/dto/ClientTokenListItemDto.java
@@ -1,6 +1,5 @@
 package com.deloitte.elrr.services.dto;
 
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 @EqualsAndHashCode(callSuper = true)
 public class ClientTokenListItemDto extends AuditableDto {
 
-    private UUID id;
     private String label;
 
 }

--- a/src/main/java/com/deloitte/elrr/services/dto/ExtensibleDto.java
+++ b/src/main/java/com/deloitte/elrr/services/dto/ExtensibleDto.java
@@ -1,5 +1,6 @@
 package com.deloitte.elrr.services.dto;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -16,6 +17,6 @@ import lombok.RequiredArgsConstructor;
 public abstract class ExtensibleDto extends AuditableDto {
 
     @ValidIriKeys
-    private Map<URI, Object> extensions;
+    private Map<URI, Serializable> extensions;
 
 }

--- a/src/main/java/com/deloitte/elrr/services/security/CustomPermissionEvaluator.java
+++ b/src/main/java/com/deloitte/elrr/services/security/CustomPermissionEvaluator.java
@@ -39,7 +39,6 @@ public class CustomPermissionEvaluator implements PermissionEvaluator {
     @Override
     public boolean hasPermission(Authentication authentication,
             Serializable targetId, String targetType, Object permission) {
-        JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
         throw new UnsupportedOperationException(
                 "hasPermission with targetId and targetType is not supported");
     }

--- a/src/main/java/com/deloitte/elrr/services/validation/IriKeysValidator.java
+++ b/src/main/java/com/deloitte/elrr/services/validation/IriKeysValidator.java
@@ -1,5 +1,6 @@
 package com.deloitte.elrr.services.validation;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 
@@ -12,7 +13,7 @@ import jakarta.validation.ConstraintValidatorContext;
  * Identifiers).
  */
 public class IriKeysValidator
-        implements ConstraintValidator<ValidIriKeys, Map<URI, Object>> {
+        implements ConstraintValidator<ValidIriKeys, Map<URI, Serializable>> {
 
     @Override
     public void initialize(ValidIriKeys constraintAnnotation) {
@@ -20,7 +21,7 @@ public class IriKeysValidator
     }
 
     @Override
-    public boolean isValid(Map<URI, Object> map,
+    public boolean isValid(Map<URI, Serializable> map,
             ConstraintValidatorContext context) {
         if (map == null) {
             return true; // null values are considered valid

--- a/src/test/java/com/deloitte/elrr/services/validation/IriKeysValidationTest.java
+++ b/src/test/java/com/deloitte/elrr/services/validation/IriKeysValidationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.Serializable;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +37,7 @@ class IriKeysValidationTest {
     @Test
     void testValidIriKeys() {
         TestExtensibleDto dto = new TestExtensibleDto();
-        Map<URI, Object> extensions = new HashMap<>();
+        Map<URI, Serializable> extensions = new HashMap<>();
         
         // Add valid IRIs (all absolute with schemes)
         extensions.put(URI.create("https://example.com/property1"), "value1");
@@ -53,7 +54,7 @@ class IriKeysValidationTest {
     @Test
     void testInvalidIriKey_SimpleWord() {
         TestExtensibleDto dto = new TestExtensibleDto();
-        Map<URI, Object> extensions = new HashMap<>();
+        Map<URI, Serializable> extensions = new HashMap<>();
         
         try {
             // "foo" gets through URI.create() but should be rejected by our validator
@@ -73,7 +74,7 @@ class IriKeysValidationTest {
     @Test
     void testInvalidIriKey_EmptyString() {
         TestExtensibleDto dto = new TestExtensibleDto();
-        Map<URI, Object> extensions = new HashMap<>();
+        Map<URI, Serializable> extensions = new HashMap<>();
         
         try {
             extensions.put(URI.create(""), "value1");

--- a/src/test/java/com/deloitte/elrr/util/ValueObjectTestUtility.java
+++ b/src/test/java/com/deloitte/elrr/util/ValueObjectTestUtility.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.lang.reflect.Constructor;
+import java.io.Serializable;
 import com.deloitte.elrr.services.dto.ExtensibleDto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -75,7 +76,7 @@ public final class ValueObjectTestUtility {
             ExtensibleDto dto = (ExtensibleDto) constructor.newInstance();
 
             // Create sample extensions
-            Map<URI, Object> extensions = new HashMap<>();
+            Map<URI, Serializable> extensions = new HashMap<>();
             extensions.put(URI.create("https://example.org/schema#socialSecurityNumber"), "123-45-6789");
             extensions.put(URI.create("https://example.org/schema#preferredName"), "Mike");
             extensions.put(URI.create("https://example.org/schema#customField"), "test value");


### PR DESCRIPTION
**Updated SQ issues:**

1. "id" is the name of a field in "AbstractDto" (elrrservices/src/main/java/com/deloitte/elrr/services/dto/ClientTokenListItemDto.java)

    - Line affected: L15
    - Child class fields should not shadow parent class fields[java:S2387 ](https://sonarqube.il2.dso.mil/coding_rules?open=java%3AS2387&rule_key=java%3AS2387)
    - Removed id in the child class, since it's the name of a field in AbstractDto
  
2. Make non-static "extensions" transient or serializable (elrrservices/src/main/java/com/deloitte/elrr/services/dto/ExtensibleDto.java)

    - Line affected: L19
    - Fields in a "Serializable" class should either be transient or serializable[java:S1948 ](https://sonarqube.il2.dso.mil/coding_rules?open=java%3AS1948&rule_key=java%3AS1948)
    - Updated object to Serializable

4. Refactor this method to reduce its Cognitive Complexity from 18 to the 15 allowed (elrrservices/src/main/java/com/deloitte/elrr/services/security/JwtRequestFilter.java)

    - Line affected: L35
    - Cognitive Complexity of methods should not be too high[java:S3776](https://sonarqube.il2.dso.mil/coding_rules?open=java%3AS3776&rule_key=java%3AS3776)
    - Made a helper function to reduce the complexity score
 
5. Remove this useless assignment to local variable "token" (elrrservices/src/main/java/com/deloitte/elrr/services/security/CustomPermissionEvaluator.java)

    - Line affected: L42
    - Unused assignments should be removed[java:S1854](https://sonarqube.il2.dso.mil/coding_rules?open=java%3AS1854&rule_key=java%3AS1854)
    - Removed unused assignment




**Vulnerable Dependencies and Actions Taken**
1. commons-beanutils-1.9.4.jar

    - Vulnerability: CVE-2025-48734
    - Affected Versions: ['<1.11.0']
    - Upgraded commons-beanutils from version 1.9.4 (previously included via commons-validator) to 1.11.0

2. gson-2.10.1.jar

    - Vulnerability: CVE-2025-53864
    - Affected Versions: ['<2.12.0']
    - Action: Upgraded from 2.10.1 to 2.12.0

3. spring-context-6.2.6.jar

    - Vulnerability: CVE-2025-22233
    - Affected Versions: ['<6.2.7']
    - Action: Upgraded from 6.2.6 to 6.2.9

6. spring-security-core-6.4.5.jar

    - Vulnerability: CVE-2025-41232
    - Affected Versions: ['<6.4.6']
    - Upgraded from 6.4.5 to 6.4.6

7. spring-web-6.2.6.jar

    - Vulnerability: CVE-2025-41234
    - Affected Versions: ['<6.2.7']
    - Action: Upgraded from 6.2.6 to 6.2.9

8. tomcat-embed-core-10.1.40.jar

    - Vulnerabilities: CVE-2025-49124, CVE-2025-48988, CVE-2025-49125, CVE-2025-52520, CVE-2025-53506, CVE-2025-46701
    - Affected Versions: ['<10.1.43']
    - Upgraded from 10.1.40 (included via spring boot 3.4.5) to 10.1.43
