### PR TITLE
Admin API Override

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -127,3 +127,9 @@ Connection: close
 [{"id":"0197fa29-957f-7d48-825a-e0f0973000b4","insertedDate":"2025-07-11T11:45:18.721718","updatedBy":null
 ...
 ```
+
+## Admin API Override Mode
+
+In this mode (enabled by setting property `client.admin-api-override` or env `ELRR_ADMIN_API_OVERRIDE` to true), the Admin JWT which normally can only request an API token is able to perform all API calls as a bearer token.
+
+**DANGER**: This is not recommended for production deployments and proper API tokens should be created instead.

--- a/src/main/java/com/deloitte/elrr/services/security/CustomPermissionEvaluator.java
+++ b/src/main/java/com/deloitte/elrr/services/security/CustomPermissionEvaluator.java
@@ -18,7 +18,7 @@ import com.deloitte.elrr.services.model.Action;
 public class CustomPermissionEvaluator implements PermissionEvaluator {
 
     @Value("${client.admin-api-override}")
-    private Boolean adminApiOverride;
+    private boolean adminApiOverride;
 
     @Override
     public boolean hasPermission(Authentication authentication, Object resource,

--- a/src/main/java/com/deloitte/elrr/services/security/CustomPermissionEvaluator.java
+++ b/src/main/java/com/deloitte/elrr/services/security/CustomPermissionEvaluator.java
@@ -3,6 +3,7 @@ package com.deloitte.elrr.services.security;
 import java.io.Serializable;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -16,9 +17,15 @@ import com.deloitte.elrr.services.model.Action;
 @Component
 public class CustomPermissionEvaluator implements PermissionEvaluator {
 
+    @Value("${client.admin-api-override}")
+    private Boolean adminApiOverride;
+
     @Override
     public boolean hasPermission(Authentication authentication, Object resource,
             Object action) {
+        if (authentication instanceof AdminJwtAuthenticationToken)
+            return adminApiOverride;
+
         JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
 
         // get permissions from token

--- a/src/main/java/com/deloitte/elrr/services/security/SecurityConfig.java
+++ b/src/main/java/com/deloitte/elrr/services/security/SecurityConfig.java
@@ -21,12 +21,9 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import lombok.extern.slf4j.Slf4j;
-
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
-@Slf4j
 public class SecurityConfig {
 
     @Autowired

--- a/src/main/java/com/deloitte/elrr/services/security/SecurityConfig.java
+++ b/src/main/java/com/deloitte/elrr/services/security/SecurityConfig.java
@@ -3,26 +3,50 @@ package com.deloitte.elrr.services.security;
 import java.util.Arrays;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+@Slf4j
 public class SecurityConfig {
 
     @Autowired
     private JwtRequestFilter jwtRequestFilter;
+
+    @Value("${client.admin-api-override}")
+    private Boolean adminApiOverride;
+
+    private boolean containsRole(Authentication auth, String role) {
+        return auth.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals(role));
+    }
+
+    private AuthorizationManager<RequestAuthorizationContext> apiAccess() {
+        return (authentication, context) -> {
+            Authentication auth = authentication.get();
+            return new AuthorizationDecision(containsRole(auth, "ROLE_API")
+                || (adminApiOverride && containsRole(auth, "ROLE_ADMIN")));
+        };
+    }
 
     /**
      * @param http httpsecurity config
@@ -45,7 +69,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/**")
-                            .hasRole("API")
+                            .access(apiAccess())
                         .requestMatchers("/admin/**")
                             .hasRole("ADMIN")
                         .anyRequest().denyAll())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -73,3 +73,4 @@ api.jwt.user-id-key=${ELRR_API_JWT_USER_ID_KEY:token-creator}
 
 # JWT Sec
 client.jwt.secret=${CLIENT_JWT_SECRET}
+client.admin-api-override=${ELRR_ADMIN_API_OVERRIDE:false}

--- a/src/test/java/com/deloitte/elrr/services/security/CustomPermissionEvaluatorTest.java
+++ b/src/test/java/com/deloitte/elrr/services/security/CustomPermissionEvaluatorTest.java
@@ -3,6 +3,7 @@ package com.deloitte.elrr.services.security;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -22,6 +23,9 @@ class CustomPermissionEvaluatorTest {
 
     @Mock
     private JwtAuthenticationToken mockToken;
+
+    @Mock
+    private AdminJwtAuthenticationToken mockAdminToken;
 
     @BeforeEach
     void setUp() {
@@ -91,6 +95,35 @@ class CustomPermissionEvaluatorTest {
         // Act
         boolean result = permissionEvaluator.hasPermission(
             mockToken, "anyResource", "READ");
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void adminToken_WithOverrideFalse_ReturnsFalse() {
+
+        // Act
+        boolean result = permissionEvaluator.hasPermission(
+            mockAdminToken, "anyResource", "READ");
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    void adminToken_WithOverrideTrue_ReturnsTrue()
+        throws NoSuchFieldException, SecurityException,
+        IllegalArgumentException, IllegalAccessException {
+
+        Field field = CustomPermissionEvaluator.class
+            .getDeclaredField("adminApiOverride");
+        field.setAccessible(true);
+        field.set(permissionEvaluator, true);
+
+        // Act
+        boolean result = permissionEvaluator.hasPermission(
+            mockAdminToken, "anyResource", "READ");
 
         // Assert
         assertTrue(result);


### PR DESCRIPTION
- Adds new env/prop to enable admin override mode
- When running in this mode, Admin JWTs will function as full permission API JWTs